### PR TITLE
Add backwards compatibility for leveldb index fetches

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,6 +358,8 @@ KV.prototype._prepare = function (fin) {
           done(err)
         })
       })
+    } else {
+      done()
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "hyperlog": "^4.7.0",
     "memdb": "^1.0.1",
     "tape": "^4.2.2",
+    "temp": "^0.8.3",
     "toposort": "^0.2.12"
   },
   "dependencies": {

--- a/prepare.js
+++ b/prepare.js
@@ -1,0 +1,27 @@
+var lock = require('mutexify')
+
+module.exports = function (prepare) {
+  var ready = false
+  var wait = lock()
+
+  // hold the lock until ready; this will succeed instantly
+  wait(function (release) {
+    // call the user prepare function; set ready when done
+    prepare(function () {
+      ready = true
+      release()
+    })
+  })
+
+  return function (cb) {
+    // already ready; return instantly
+    if (ready) return cb()
+
+    // not ready yet; wait until the lock is released
+    wait(function (release) {
+      release()
+      cb()
+    })
+  }
+}
+

--- a/test/backwards_compat_indexes.js
+++ b/test/backwards_compat_indexes.js
@@ -2,31 +2,129 @@ var test = require('tape')
 var hyperkv = require('../')
 var memdb = require('memdb')
 var hyperlog = require('hyperlog')
+var temp = require('temp')
+var level = require('level')
+var sub = require('subleveldown')
+
+// 1. create kv instance, manually edit xdb, create new kv instance + ensure works
+// 2. two subsequent uses on same version works okay
 
 test('1.x format to 2.x format', function (t) {
-  t.plan(4)
+  t.plan(8)
 
-  var kv = hyperkv({
-    log: hyperlog(memdb(), { valueEncoding: 'json' }),
-    db: memdb()
+  var db
+  var levelPath
+
+  temp.track()
+  temp.mkdir('hyperkv-test-bw-compat', function (err, dirPath) {
+    t.ifError(err)
+    levelPath = dirPath
+    db = level(dirPath)
+    create1xx()
   })
 
-  kv.put('foo', 'bar', function (err, node) {
-    t.ifError(err)
-    kv.dex.ready(function () {
-      // write expected old format
-      kv.xdb.put('foo', [ node.key ], function (err) {
-        t.ifError(err)
-        // make a fetch, which will grab the value in the old db format just
-        // written
-        kv.get('foo', function (err, values) {
+  function create1xx () {
+    var kv = hyperkv({
+      log: hyperlog(sub(db, 'log'), { valueEncoding: 'json' }),
+      db: sub(db, 'kv')
+    })
+
+    kv.put('foo', 'bar', function (err, node) {
+      t.ifError(err)
+      kv._ready(function () {
+        // write expected old format
+        kv.xdb.put('foo', [ node.key ], function (err) {
           t.ifError(err)
-          var expected = {}
-          expected[node.key] = { value: 'bar' }
-          t.deepEqual(values, expected)
-          t.end()
+          // fudge version value
+          kv.xdbMeta.put('version', 1, function (err) {
+            t.ifError(err)
+            // shutdown the db and walk away
+            kv.xdb.close(function (err) {
+              t.ifError(err)
+              kv.idb.close(function (err) {
+                t.ifError(err)
+                create2xx(node.key)
+              })
+            })
+          })
         })
       })
     })
+  }
+
+  function create2xx (key) {
+    // new kv
+    var db = level(levelPath)
+    var kv = hyperkv({
+      log: hyperlog(sub(db, 'log'), { valueEncoding: 'json' }),
+      db: sub(db, 'kv')
+    })
+
+    // make a fetch, which will grab the value in the old db format just
+    // written
+    kv._ready(function () {
+      kv.get('foo', function (err, values) {
+        t.ifError(err)
+        var expected = {}
+        expected[key] = { value: 'bar' }
+        t.deepEqual(values, expected)
+        t.end()
+      })
+    })
+  }
+})
+
+test('2.x format used twice in a row', function (t) {
+  t.plan(6)
+
+  var db
+  var levelPath
+
+  temp.track()
+  temp.mkdir('hyperkv-test-bw-compat', function (err, dirPath) {
+    t.ifError(err)
+    levelPath = dirPath
+    db = level(dirPath)
+    createFirst()
   })
+
+  function createFirst () {
+    var kv = hyperkv({
+      log: hyperlog(sub(db, 'log'), { valueEncoding: 'json' }),
+      db: sub(db, 'kv')
+    })
+
+    kv.put('foo', 'bar', function (err, node) {
+      t.ifError(err)
+      kv._ready(function () {
+        // shutdown the db and walk away
+        kv.xdb.close(function (err) {
+          t.ifError(err)
+          kv.idb.close(function (err) {
+            t.ifError(err)
+            createSecond(node.key)
+          })
+        })
+      })
+    })
+  }
+
+  function createSecond (key) {
+    // new kv
+    var db = level(levelPath)
+    var kv = hyperkv({
+      log: hyperlog(sub(db, 'log'), { valueEncoding: 'json' }),
+      db: sub(db, 'kv')
+    })
+
+    kv._ready(function () {
+      kv.get('foo', function (err, values) {
+        t.ifError(err)
+        var expected = {}
+        expected[key] = { value: 'bar' }
+        t.deepEqual(values, expected)
+        t.end()
+      })
+    })
+  }
 })

--- a/test/backwards_compat_indexes.js
+++ b/test/backwards_compat_indexes.js
@@ -1,0 +1,32 @@
+var test = require('tape')
+var hyperkv = require('../')
+var memdb = require('memdb')
+var hyperlog = require('hyperlog')
+
+test('1.x format to 2.x format', function (t) {
+  t.plan(4)
+
+  var kv = hyperkv({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb()
+  })
+
+  kv.put('foo', 'bar', function (err, node) {
+    t.ifError(err)
+    kv.dex.ready(function () {
+      // write expected old format
+      kv.xdb.put('foo', [ node.key ], function (err) {
+        t.ifError(err)
+        // make a fetch, which will grab the value in the old db format just
+        // written
+        kv.get('foo', function (err, values) {
+          t.ifError(err)
+          var expected = {}
+          expected[node.key] = { value: 'bar' }
+          t.deepEqual(values, expected)
+          t.end()
+        })
+      })
+    })
+  })
+})

--- a/wipe-levelup.js
+++ b/wipe-levelup.js
@@ -1,0 +1,11 @@
+module.exports = function (db, done) {
+  var ops = []
+  db.createKeyStream()
+    .on('data', function (key) {
+      ops.push({ type: 'del', key: key })
+    })
+    .once('end', function () {
+      db.batch(ops, done)
+    })
+    .once('error', done)
+}


### PR DESCRIPTION
This makes hyperkv@2.x.x understand the old (1.x.x) leveldb index format, and convert it to the new format at runtime. This patch will let us deploy hyperkv@2.x.x to existing databases without needing to manually intervene and nuke user indexes.