### PR TITLE
Add missing dependency 'pump'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mkdirp": "^0.5.1",
     "mutexify": "^1.1.0",
     "once": "^1.3.3",
+    "pump": "^1.0.2",
     "read-only-stream": "^2.0.0",
     "readable-stream": "^2.0.5",
     "subleveldown": "^2.1.0",


### PR DESCRIPTION
It looks like this isn't always a problem, since hyperlog pulls in `pump` too. However, in [certain circumstances](https://github.com/substack/norcal/issues/7), like when a module depends on both `hyperlog` and `hyperkv`, `hyperlog`'s `pump` will be insulated from `hyperkv`, resulting in failure.