### PR TITLE
Expose `value` on surfaced deletions when present.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,13 @@ KV.prototype.get = function (key, opts, cb) {
       keys.forEach(function (key) {
         self.log.get(key, function (err, doc) {
           if (err) return cb(err)
-          if (docs[key] === 'put') {
-            values[key] = opts.fields ? doc.value : { value: doc.value.v }
+          if (opts.fields) {
+            values[key] = doc.value
+          } else if (docs[key] === 'put') {
+            values[key] = { value: doc.value.v }
           } else if (docs[key] === 'del') {
-            values[key] = opts.fields ? doc.value : { deleted: true }
+            values[key] = { deleted: true }
+            if (doc.value.v) values[key].value = doc.value.v
           }
           else return cb(new Error('unknown type'))
           if (--pending === 0) cb(null, values)

--- a/readme.markdown
+++ b/readme.markdown
@@ -100,7 +100,7 @@ hyperlog hashes to set values.
 Each value is an object of one of two forms:
 
 - `{ value: ... }` - the value of the key
-- `{ deleted: true }` - tombstone indicating the key has been deleted
+- `{ deleted: true, value: ... }` - tombstone indicating the key has been deleted (with optional value)
 
 It is possible to receive both types for the same key; it is left up to the api
 consumer to decide how the data is best interpreted.
@@ -120,6 +120,8 @@ refer to the current "head" key hashes.
 Note that keys are only removed with respect to `opts.links`, not globally and
 that edits made in forks may cause deleted keys to "reappear". This is by
 design.
+
+If `opts.value` is set, the deletion tombstone will include a value.
 
 `cb(err, node)` fires from the underlying `log.add()` call.
 

--- a/test/del_batch.js
+++ b/test/del_batch.js
@@ -1,0 +1,44 @@
+var test = require('tape')
+var hyperkv = require('../')
+var memdb = require('memdb')
+var hyperlog = require('hyperlog')
+
+test('batch', function (t) {
+  t.plan(6)
+
+  var kv = hyperkv({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb()
+  })
+  kv.batch([
+    { type: 'put', key: 'A', value: 123 },
+    { type: 'put', key: 'B', value: 456 },
+  ], onbatch)
+
+  var putNodes
+
+  function onbatch (err, nodes) {
+    t.error(err)
+    putNodes = nodes
+    kv.batch([
+      { type: 'del', key: 'A', fields: { v: 900 } }
+    ], onbatch2)
+  }
+
+  function onbatch2 (err, delNodes) {
+    t.error(err)
+    kv.get('A', function (err, values) {
+      t.error(err)
+      var expected = {}
+      expected[delNodes[0].key] = { deleted: true, value: 900 }
+      t.deepEqual(values, expected, 'expected values for key A')
+    })
+    kv.get('B', function (err, values) {
+      t.error(err)
+      var expected = {}
+      expected[putNodes[1].key] = { value: 456 }
+      t.deepEqual(values, expected, 'expected values for key B')
+    })
+  }
+})
+


### PR DESCRIPTION
Currently `kv.get()` will only return `node.value.v` as `value` on non-deletions only.

This PR modifies the `kv.get` API such that `value` is exposed on deletion documents as well, when present. Since this only adds a new key onto documents returned from `kv.get`, it should only require a minor semver bump!

This change will bubble up to `osm-p2p-db`, where I'd like to store a `type` key on deletion tombstones of OSM documents. With this change to `hyperkv`, an extra lookup can be avoided in order to see the value on the deleted document.